### PR TITLE
Fix syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ go get github.com/b3ntly/distributed-token-bucket
 package main
 
 import (
-    tb "github.com/b3ntly/distributed-token-bucket
+    tb "github.com/b3ntly/distributed-token-bucket"
     "github.com/go-redis/redis"
 )
 


### PR DESCRIPTION
The missing `"` was causing the syntax highlighter to fail.